### PR TITLE
Fix build warning: 'const' qualifier on reference type

### DIFF
--- a/include/htcw_data.hpp
+++ b/include/htcw_data.hpp
@@ -430,7 +430,7 @@ class simple_list {
 
        public:
         using value_type = T;
-        const reference operator*() const { return m_current->value; }
+        reference operator*() const { return m_current->value; }
         pointer operator->() const { return &m_current->value; }
         // Prefix increment
         const_iterator& operator++() const {


### PR DESCRIPTION
Fix the following build warning:

    In file included from .pio/libdeps/native/htcw_gfx/src/gfx_open_font.cpp:9:
    In file included from .pio/libdeps/native/htcw_gfx/include/gfx_open_font.hpp:4:
    .pio/libdeps/native/htcw_data/include/htcw_data.hpp:433:9: warning:
      'const' qualifier on reference type 'reference' (aka 'T &')
      has no effect [-Wignored-reference-qualifiers]
            const reference operator*() const { return m_current->value; }
            ^~~~~~